### PR TITLE
fix_browser_demo_page

### DIFF
--- a/browser_demo.html
+++ b/browser_demo.html
@@ -3,7 +3,7 @@
 <head>
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 	<title>OpenTok Hello World</title>
-	<script src='http://static.opentok.com/webrtc/v2.0/js/TB.min.js'></script>
+	<script src='http://static.opentok.com/webrtc/v2.2/js/opentok.min.js'></script>
 	<script type="text/javascript" charset="utf-8">
 
 		// *** Fill the following variables using your own Project info from the Dashboard  ***
@@ -57,7 +57,12 @@
 				publisherProperties.name = 'A web-based OpenTok client';
 				publisherDiv.setAttribute('id', 'opentok_publisher');
 				parentDiv.appendChild(publisherDiv);
-				publisher = session.publish(publisherDiv.id, publisherProperties); // Pass the replacement div id to the publish method
+				publisher = OT.initPublisher(publisherDiv.id, publisherProperties);
+				session.publish(publisher, function(error) {
+			    	if (error) {
+			          console.log('The publisher failed to connect.');
+			    	}
+			    });
 				show('unpublishLink');
 				hide('publishLink');
 			}


### PR DESCRIPTION
Hi!
A bug fix was made inside the file called "browser_demo.html".
The publisher was not being initiated, so developers were not able to receive streams on the android samples when they set subscribe_to_self to false to emulate a second user.

Thanks,
Marcio