### PR TITLE
- Fix issues with Stream UI Position

### DIFF
--- a/Simple-Multiparty/app/src/main/java/com/tokbox/android/tutorials/simple_multiparty/MainActivity.java
+++ b/Simple-Multiparty/app/src/main/java/com/tokbox/android/tutorials/simple_multiparty/MainActivity.java
@@ -45,6 +45,7 @@ public class MainActivity extends AppCompatActivity
 
     private ArrayList<Subscriber> mSubscribers = new ArrayList<Subscriber>();
     private HashMap<Stream, Subscriber> mSubscriberStreams = new HashMap<Stream, Subscriber>();
+    private HashMap<Stream, Integer> mSubscriberPosition = new HashMap<Stream, Integer>();
 
     private RelativeLayout mPublisherViewContainer;
 
@@ -244,14 +245,19 @@ public class MainActivity extends AppCompatActivity
         mSession.subscribe(subscriber);
         mSubscribers.add(subscriber);
         mSubscriberStreams.put(stream, subscriber);
-
-        int position = mSubscribers.size() - 1;
+        int position = 0;
+        for (int i = 0; i < MAX_NUM_SUBSCRIBERS; i++) {
+            if (mSubscriberPosition.containsValue(i) == false) {
+                 position = i;
+                 break;
+            }
+        }
+        mSubscriberPosition.put(stream, position);
         int id = getResources().getIdentifier("subscriberview" + (new Integer(position)).toString(), "id", MainActivity.this.getPackageName());
         RelativeLayout subscriberViewContainer = (RelativeLayout) findViewById(id);
 
         subscriber.setStyle(BaseVideoRenderer.STYLE_VIDEO_SCALE, BaseVideoRenderer.STYLE_VIDEO_FILL);
         subscriberViewContainer.addView(subscriber.getView());
-
         id = getResources().getIdentifier("toggleAudioSubscriber" + (new Integer(position)).toString(), "id", MainActivity.this.getPackageName());
         final ToggleButton toggleAudio = (ToggleButton) findViewById(id);
         toggleAudio.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -275,12 +281,12 @@ public class MainActivity extends AppCompatActivity
             return;
         }
 
-        int position = mSubscribers.indexOf(subscriber);
+        int position = mSubscriberPosition.get(stream);
         int id = getResources().getIdentifier("subscriberview" + (new Integer(position)).toString(), "id", MainActivity.this.getPackageName());
 
         mSubscribers.remove(subscriber);
         mSubscriberStreams.remove(stream);
-
+        mSubscriberPosition.remove(stream);
         RelativeLayout subscriberViewContainer = (RelativeLayout) findViewById(id);
         subscriberViewContainer.removeView(subscriber.getView());
 


### PR DESCRIPTION
This PR fixes issues with Stream UI position logic. 

Steps to repro:
1. launch simple multipart (listeners on streamReceived and Dropped)
2. connect with Web using Opentok Playground
3. Publish first stream with Chrome (streamReceived - ID: xxx306)
4. Publish second stream with Chrome (streamReceived - ID: xxx307)
5. Unpublish first stream with chrome (streamDropped - ID: xxx306)
6. Publish third stream with Chrome (streamReceived - ID: xxx307)
7. Unpublish with Chrome (streamDropped - ID: xxx306)

This flow will break the UI and streams will overlay.
CC @robjperez 