### PR TITLE
OPENTOK-43278: Replace Android samples bintray links with Maven Central links

### DIFF
--- a/ARCore-Integration/build.gradle
+++ b/ARCore-Integration/build.gradle
@@ -25,7 +25,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/ARCore-Integration/build.gradle
+++ b/ARCore-Integration/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Advanced-Audio-Driver/build.gradle
+++ b/Advanced-Audio-Driver/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Advanced-Audio-Driver/build.gradle
+++ b/Advanced-Audio-Driver/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Archiving/build.gradle
+++ b/Archiving/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Archiving/build.gradle
+++ b/Archiving/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Audio-Driver/build.gradle
+++ b/Basic-Audio-Driver/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Audio-Driver/build.gradle
+++ b/Basic-Audio-Driver/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Video-Capturer-Camera-2/build.gradle
+++ b/Basic-Video-Capturer-Camera-2/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Video-Capturer-Camera-2/build.gradle
+++ b/Basic-Video-Capturer-Camera-2/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Video-Capturer/build.gradle
+++ b/Basic-Video-Capturer/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Video-Capturer/build.gradle
+++ b/Basic-Video-Capturer/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Video-Chat/build.gradle
+++ b/Basic-Video-Chat/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Video-Chat/build.gradle
+++ b/Basic-Video-Chat/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Video-Driver/build.gradle
+++ b/Basic-Video-Driver/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Video-Driver/build.gradle
+++ b/Basic-Video-Driver/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Basic-Video-Renderer/build.gradle
+++ b/Basic-Video-Renderer/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Basic-Video-Renderer/build.gradle
+++ b/Basic-Video-Renderer/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Frame-Metadata/build.gradle
+++ b/Frame-Metadata/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Frame-Metadata/build.gradle
+++ b/Frame-Metadata/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Live-Photo-Capture/build.gradle
+++ b/Live-Photo-Capture/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Live-Photo-Capture/build.gradle
+++ b/Live-Photo-Capture/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Multiparty-Constraint-Layout/build.gradle
+++ b/Multiparty-Constraint-Layout/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Multiparty-Constraint-Layout/build.gradle
+++ b/Multiparty-Constraint-Layout/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Picture-In-Picture/build.gradle
+++ b/Picture-In-Picture/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Picture-In-Picture/build.gradle
+++ b/Picture-In-Picture/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Screen-Sharing/build.gradle
+++ b/Screen-Sharing/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Screen-Sharing/build.gradle
+++ b/Screen-Sharing/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Signaling/build.gradle
+++ b/Signaling/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Signaling/build.gradle
+++ b/Signaling/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }

--- a/Simple-Multiparty/build.gradle
+++ b/Simple-Multiparty/build.gradle
@@ -24,7 +24,6 @@ allprojects {
         jcenter()
 
         repositories {
-            jcenter()
             mavenCentral()
         }
     }

--- a/Simple-Multiparty/build.gradle
+++ b/Simple-Multiparty/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
         repositories {
             jcenter()
-            maven { url 'https://tokbox.bintray.com/maven' }
+            mavenCentral()
         }
     }
 }


### PR DESCRIPTION
Replace Android samples bintray links with Maven Central links. 