### PR TITLE
Set local render mirroring when using front camera

### DIFF
--- a/Basic-Video-Capturer-Camera-2-Java/README.md
+++ b/Basic-Video-Capturer-Camera-2-Java/README.md
@@ -20,7 +20,7 @@ publisher = new Publisher.Builder(MainActivity.this)
     .build();
 ```
 
-The `getCaptureSettings` method returns the settings of the video capturer, including the frame rate, width, height, video delay, and video format for the capturer:
+The `getCaptureSettings` method returns the settings of the video capturer, including the frame rate, width, height, video delay, video format, and mirroring for the capturer:
 
 ```java
 @Override
@@ -31,6 +31,7 @@ public synchronized CaptureSettings getCaptureSettings() {
     captureSettings.height = (null != cameraFrame) ? cameraFrame.getHeight() : 0;
     captureSettings.format = BaseVideoCapturer.NV21;
     captureSettings.expectedDelay = 0;
+    captureSettings.mirrorInLocalRender = isFrontCamera();
     return captureSettings;
 }
 ```

--- a/Basic-Video-Capturer-Camera-2-Java/app/src/main/java/com/tokbox/sample/basicvideocapturercamera2/MirrorVideoCapturer.java
+++ b/Basic-Video-Capturer-Camera-2-Java/app/src/main/java/com/tokbox/sample/basicvideocapturercamera2/MirrorVideoCapturer.java
@@ -466,6 +466,7 @@ class MirrorVideoCapturer extends BaseVideoCapturer implements BaseVideoCapturer
         captureSettings.height = (null != cameraFrame) ? cameraFrame.getHeight() : 0;
         captureSettings.format = BaseVideoCapturer.NV21;
         captureSettings.expectedDelay = 0;
+        captureSettings.mirrorInLocalRender = isFrontCamera();
         return captureSettings;
     }
 


### PR DESCRIPTION
Hi!

I noticed that the MirrorVideoCapturer was not in fact mirroring the front camera video in the local render. If that's the intention here, it looks this needs to be updated to support the `captureSetting.mirrorInLocalRender` flag added in 2.17.0.

