### PR TITLE
Opentok 47720 - Update samples for Android SKD regarding the use of Custom Audio Driver and READ_PHONE_STATE permission

### DIFF
--- a/Advanced-Audio-Driver-Java/app/src/main/AndroidManifest.xml
+++ b/Advanced-Audio-Driver-Java/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />

--- a/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1,5 +1,6 @@
 package com.tokbox.sample.advancedaudiodriver;
 
+import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothHeadset;
@@ -8,6 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioRecord;
@@ -1005,7 +1007,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         if (Build.VERSION.SDK_INT >= 31) {
             if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
                     != PackageManager.PERMISSION_GRANTED) {
-                log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                Log.e(TAG, "Some features may not be available unless the phone permissions has been granted explicitly " +
                         "in the App settings.");
                 return false;
             }
@@ -1021,7 +1023,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+            Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }
@@ -1040,7 +1042,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+            Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }

--- a/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1000,6 +1000,19 @@ class AdvancedAudioDevice extends BaseAudioDevice {
 
     private boolean isPhoneStateListenerRegistered;
 
+    //Phone state permissions are required to from Api 31. Adding this check to avoid crash.
+    private boolean hasPhoneStatePermission() {
+        if (Build.VERSION.SDK_INT >= 31) {
+            if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
+                    != PackageManager.PERMISSION_GRANTED) {
+                log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                        "in the App settings.");
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void registerPhoneStateListener() {
         Log.d(TAG, "registerPhoneStateListener() called");
 
@@ -1007,7 +1020,14 @@ class AdvancedAudioDevice extends BaseAudioDevice {
             return;
         }
 
+        if (!hasPhoneStatePermission()) {
+            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                    "be completed.");
+            return;
+        }
+
         if (telephonyManager != null) {
+            // add snippet code from Jint
             telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
             isPhoneStateListenerRegistered = true;
         }
@@ -1017,6 +1037,12 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         Log.d(TAG, "unRegisterPhoneStateListener() called");
 
         if (!isPhoneStateListenerRegistered) {
+            return;
+        }
+
+        if (!hasPhoneStatePermission()) {
+            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                    "be completed.");
             return;
         }
 

--- a/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1023,7 +1023,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
+            Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }
@@ -1042,7 +1042,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
+            Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }

--- a/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Java/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1027,7 +1027,6 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (telephonyManager != null) {
-            // add snippet code from Jint
             telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
             isPhoneStateListenerRegistered = true;
         }

--- a/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1,5 +1,6 @@
 package com.tokbox.sample.advancedaudiodriver;
 
+import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothHeadset;
@@ -8,6 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioRecord;
@@ -1005,7 +1007,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         if (Build.VERSION.SDK_INT >= 31) {
             if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
                     != PackageManager.PERMISSION_GRANTED) {
-                log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                Log.e(TAG, "Some features may not be available unless the phone permissions has been granted explicitly " +
                         "in the App settings.");
                 return false;
             }
@@ -1019,9 +1021,9 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         if (isPhoneStateListenerRegistered) {
             return;
         }
-
+        
         if (!hasPhoneStatePermission()) {
-            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+            Log.d(TAG,"No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }
@@ -1040,7 +1042,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+            Log.d(TAG,"No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }

--- a/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1000,10 +1000,29 @@ class AdvancedAudioDevice extends BaseAudioDevice {
 
     private boolean isPhoneStateListenerRegistered;
 
+    //Phone state permissions are required to from Api 31. Adding this check to avoid crash.
+    private boolean hasPhoneStatePermission() {
+        if (Build.VERSION.SDK_INT >= 31) {
+            if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
+                    != PackageManager.PERMISSION_GRANTED) {
+                log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                        "in the App settings.");
+                return false;
+            }
+        }
+        return true;
+    }
+
     private void registerPhoneStateListener() {
         Log.d(TAG, "registerPhoneStateListener() called");
 
         if (isPhoneStateListenerRegistered) {
+            return;
+        }
+
+        if (!hasPhoneStatePermission()) {
+            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                    "be completed.");
             return;
         }
 
@@ -1017,6 +1036,12 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         Log.d(TAG, "unRegisterPhoneStateListener() called");
 
         if (!isPhoneStateListenerRegistered) {
+            return;
+        }
+
+        if (!hasPhoneStatePermission()) {
+            log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                    "be completed.");
             return;
         }
 

--- a/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
+++ b/Advanced-Audio-Driver-Kotlin/app/src/main/java/com/tokbox/sample/advancedaudiodriver/AdvancedAudioDevice.java
@@ -1023,7 +1023,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
         
         if (!hasPhoneStatePermission()) {
-            Log.d(TAG,"No Phone State permissions. Register phoneStateListener cannot " +
+            Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }
@@ -1042,7 +1042,7 @@ class AdvancedAudioDevice extends BaseAudioDevice {
         }
 
         if (!hasPhoneStatePermission()) {
-            Log.d(TAG,"No Phone State permissions. Register phoneStateListener cannot " +
+            Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                     "be completed.");
             return;
         }

--- a/Phone-Call-Detection-Java/README.md
+++ b/Phone-Call-Detection-Java/README.md
@@ -17,6 +17,7 @@ This is the code responsible for listening for the call status:
 
 ```java
 TelephonyManager telephonyManager = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
+//Phone state permissions are required from Api 31. Add check of permission to avoid crash.
 telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
 
 //...

--- a/Phone-Call-Detection-Java/app/src/main/AndroidManifest.xml
+++ b/Phone-Call-Detection-Java/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />

--- a/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
+++ b/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
             TelephonyManager telephonyManager = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
 
             if (!hasPhoneStatePermission()) {
-                Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
+                Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                         "be completed.");
                 return;
             }

--- a/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
+++ b/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
@@ -71,8 +71,27 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
             session.publish(publisher);
         }
 
+        private boolean hasPhoneStatePermission() {
+            if (Build.VERSION.SDK_INT >= 31) {
+                if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
+                        != PackageManager.PERMISSION_GRANTED) {
+                    log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                            "in the App settings.");
+                    return false;
+                }
+            }
+            return true;
+        }
+
         private void registerPhoneListener() {
             TelephonyManager telephonyManager = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
+
+            if (!hasPhoneStatePermission()) {
+                log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                        "be completed.");
+                return;
+            }
+            
             telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
         }
 

--- a/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
+++ b/Phone-Call-Detection-Java/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.java
@@ -2,7 +2,9 @@ package com.tokbox.sample.phonecalldetection;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.opengl.GLSurfaceView;
+import android.os.Build;
 import android.os.Bundle;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
@@ -21,6 +23,8 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity implements EasyPermissions.PermissionCallbacks {
 
     private static final String TAG = MainActivity.class.getSimpleName();
+
+    private Context context;
 
     private static final int PERMISSIONS_REQUEST_CODE = 124;
 
@@ -75,7 +79,7 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
             if (Build.VERSION.SDK_INT >= 31) {
                 if (context.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
                         != PackageManager.PERMISSION_GRANTED) {
-                    log.e("Some features may not be available unless the phone permissions has been granted explicitly " +
+                    Log.e(TAG,"Some features may not be available unless the phone permissions has been granted explicitly " +
                             "in the App settings.");
                     return false;
                 }
@@ -87,7 +91,7 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
             TelephonyManager telephonyManager = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
 
             if (!hasPhoneStatePermission()) {
-                log.d("No Phone State permissions. Register phoneStateListener cannot " +
+                Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                         "be completed.");
                 return;
             }
@@ -231,6 +235,8 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
                 return;
             }
 
+            setContext(this);
+
             initializeSession(OpenTokConfig.API_KEY, OpenTokConfig.SESSION_ID, OpenTokConfig.TOKEN);
         } else {
             EasyPermissions.requestPermissions(this, getString(R.string.rationale_video_app), PERMISSIONS_REQUEST_CODE, perms);
@@ -256,5 +262,10 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
         Log.e(TAG, message);
         Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         this.finish();
+    }
+
+    private void setContext(Context context)
+    {
+        this.context = context;
     }
 }

--- a/Phone-Call-Detection-Kotlin/README.md
+++ b/Phone-Call-Detection-Kotlin/README.md
@@ -17,6 +17,7 @@ This is the code responsible for listening for the call status:
 
 ```java
 TelephonyManager telephonyManager = (TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE);
+//Phone state permissions are required from Api 31. Add check of permission to avoid crash.
 telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
 
 //...

--- a/Phone-Call-Detection-Kotlin/app/src/main/AndroidManifest.xml
+++ b/Phone-Call-Detection-Kotlin/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />

--- a/Phone-Call-Detection-Kotlin/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.kt
+++ b/Phone-Call-Detection-Kotlin/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.kt
@@ -1,7 +1,10 @@
 package com.tokbox.sample.phonecalldetection
 
 import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.opengl.GLSurfaceView
+import android.os.Build
 import android.os.Bundle
 import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
@@ -9,16 +12,9 @@ import android.util.Log
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import com.opentok.android.BaseVideoRenderer
-import com.opentok.android.OpentokError
-import com.opentok.android.Publisher
-import com.opentok.android.PublisherKit
+import com.opentok.android.*
 import com.opentok.android.PublisherKit.PublisherListener
-import com.opentok.android.Session
 import com.opentok.android.Session.SessionListener
-import com.opentok.android.Stream
-import com.opentok.android.Subscriber
-import com.opentok.android.SubscriberKit
 import com.opentok.android.SubscriberKit.SubscriberListener
 import com.tokbox.sample.phonecalldetection.MainActivity
 import com.tokbox.sample.phonecalldetection.OpenTokConfig.description
@@ -27,10 +23,12 @@ import pub.devrel.easypermissions.AfterPermissionGranted
 import pub.devrel.easypermissions.EasyPermissions
 import pub.devrel.easypermissions.EasyPermissions.PermissionCallbacks
 
+
 class MainActivity : AppCompatActivity(), PermissionCallbacks {
     private var session: Session? = null
     private var publisher: Publisher? = null
     private var subscriber: Subscriber? = null
+    private var context: Context? = null
 
     private lateinit var publisherViewContainer: FrameLayout
     private lateinit var subscriberViewContainer: FrameLayout
@@ -69,8 +67,27 @@ class MainActivity : AppCompatActivity(), PermissionCallbacks {
             session.publish(publisher)
         }
 
+        private fun hasPhoneStatePermission(): Boolean {
+            if (Build.VERSION.SDK_INT >= 31) {
+                if (context!!.checkSelfPermission(Manifest.permission.READ_PHONE_STATE)
+                        != PackageManager.PERMISSION_GRANTED) {
+                    Log.e(TAG, "Some features may not be available unless the phone permissions has been granted explicitly " +
+                            "in the App settings.")
+                    return false
+                }
+            }
+            return true
+        }
+
         private fun registerPhoneListener() {
-            val telephonyManager = getSystemService(TELEPHONY_SERVICE) as TelephonyManager
+            var telephonyManager = getSystemService(TELEPHONY_SERVICE) as TelephonyManager
+
+            if (!hasPhoneStatePermission()) {
+                Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
+                        "be completed.");
+                return;
+            }
+
             telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE)
         }
 
@@ -188,6 +205,8 @@ class MainActivity : AppCompatActivity(), PermissionCallbacks {
                 return
             }
 
+            setContext(this);
+            
             initializeSession(OpenTokConfig.API_KEY, OpenTokConfig.SESSION_ID, OpenTokConfig.TOKEN)
         } else {
             EasyPermissions.requestPermissions(
@@ -223,5 +242,9 @@ class MainActivity : AppCompatActivity(), PermissionCallbacks {
     companion object {
         private val TAG = MainActivity::class.java.simpleName
         private const val PERMISSIONS_REQUEST_CODE = 124
+    }
+
+    private fun setContext(_context: Context) {
+        context = _context
     }
 }

--- a/Phone-Call-Detection-Kotlin/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.kt
+++ b/Phone-Call-Detection-Kotlin/app/src/main/java/com/tokbox/sample/phonecalldetection/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity(), PermissionCallbacks {
             var telephonyManager = getSystemService(TELEPHONY_SERVICE) as TelephonyManager
 
             if (!hasPhoneStatePermission()) {
-                Log.d(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
+                Log.e(TAG, "No Phone State permissions. Register phoneStateListener cannot " +
                         "be completed.");
                 return;
             }


### PR DESCRIPTION
**What is this PR doing?**

READ_PHONE_STATE permission is needed, on versions built targeting API level 31 can react appropriately to incoming and outgoing calls. In case the permissions are not granted, to prevent a crash, validations of current version were added.

**How should this be manually tested?**

Configure following versions:
- Android API >= 31;
- OpenTok >= 2.22.0

Run samples mentioned below on Android Studio:
- Advanced Audio Driver Java;
- Advanced Audio Driver Kotlin;
- Phone Call Detection Java;
- Phone Call Detection Kotlin;

For each one, verify if when connecting and publishing using Playground, the app does not crash.

**What are the relevant tickets?**
[OPENTOK-47720](https://jira.vonage.com/browse/OPENTOK-47720)
