### PR TITLE
VIDCS-737: Update OPENTOK version on android-sdk-samples

### DIFF
--- a/commons.gradle
+++ b/commons.gradle
@@ -12,7 +12,7 @@ ext {
     extVersionCode=1
     extVersionName="1.0"
     extMinifyEnabled=false
-    extOpentokSdkVersion="2.23.1"
+    extOpentokSdkVersion="2.25.0"
 
     extAppCompatVersion="1.4.1"
     extEasyPermissionsVersion="3.0.0"


### PR DESCRIPTION
Hi, OPENTOK version is updated using 2.25.0 in this pr.