### PR TITLE
VIDCS-885: Update opentok-android-sdk-samples to use 2.25.1

### DIFF
--- a/commons.gradle
+++ b/commons.gradle
@@ -12,7 +12,7 @@ ext {
     extVersionCode=1
     extVersionName="1.0"
     extMinifyEnabled=false
-    extOpentokSdkVersion="2.23.1"
+    extOpentokSdkVersion="2.25.1"
 
     extAppCompatVersion="1.4.1"
     extEasyPermissionsVersion="3.0.0"


### PR DESCRIPTION
Hi , extOpentokSdkVersion was updated as 2.25.1 on  commons.gradle file in  this pr