### PR TITLE
VIDCS-1215: Custom transformers - center logo watermark

### DIFF
--- a/Video-Transformers-Java/app/src/main/java/com/tokbox/sample/videotransformers/MainActivity.java
+++ b/Video-Transformers-Java/app/src/main/java/com/tokbox/sample/videotransformers/MainActivity.java
@@ -322,8 +322,8 @@ public class MainActivity extends AppCompatActivity implements EasyPermissions.P
             int logoHeight = image.getHeight();
 
             // Location of the image (center of video)
-            int logoPositionX = videoWidth * 1/5 - logoWidth; // Adjust this as needed for the desired position
-            int logoPositionY = videoHeight * 9/10 - logoHeight; // Adjust this as needed for the desired position
+            int logoPositionX = videoWidth * 1/2 - logoWidth; // Adjust this as needed for the desired position
+            int logoPositionY = videoHeight * 1/2 - logoHeight; // Adjust this as needed for the desired position
 
             // Overlay the logo on the video frame
             for (int y = 0; y < logoHeight; y++) {


### PR DESCRIPTION
Logo Watermark was not visible in some subscribers due to its displaying configurations. Placing the custom transformer logo on center of video frame should solve the issue and be visible in all devices.

https://jira.vonage.com/browse/VIDCS-1215