### PR TITLE
VIDSOL-133: Fix GHA permissions mend scan issue

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   recordMetrics:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix: https://github.com/opentok/opentok-android-sdk-samples/issues/507

Restrict Aggregit workflow to minimal permissions by setting `permissions: contents: read`.
This should maintain the functionality while improving security.

https://jira.vonage.com/browse/VIDSOL-133